### PR TITLE
Use block-based reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 SharpLauncher.csproj.user
 .editorconfig
 Properties/PublishProfiles/
+filters.json
+obj
+bin
+.vs
+Data

--- a/Config.cs
+++ b/Config.cs
@@ -9,29 +9,32 @@ namespace SharpLauncher
         public static string FlashpointPath { get; set; } = ".";
         public static string CLIFpPath { get; set; } = @".\CLIFp\CLIFp.exe";
         public static string FlashpointServer { get; set; } = "http://infinity.unstable.life/Flashpoint";
-
+        public static readonly object configJsonLock = new();
         public static bool NeedsRefresh { get; set; } = true;
 
         // Replace data with values from config file
         public static void Read()
         {
-            using (StreamReader jsonStream = new("config.json"))
+            lock (configJsonLock)
             {
-                JObject readConfig = JObject.Parse(jsonStream.ReadToEnd());
-
-                if (((JToken)readConfig["FlashpointPath"]).Type != JTokenType.Null)
+                using (StreamReader jsonStream = new("config.json"))
                 {
-                    Config.FlashpointPath = (string?)readConfig["FlashpointPath"];
-                }
+                    JObject readConfig = JObject.Parse(jsonStream.ReadToEnd());
 
-                if (((JToken)readConfig["CLIFpPath"]).Type != JTokenType.Null)
-                {
-                    Config.CLIFpPath = (string?)readConfig["CLIFpPath"];
-                }
+                    if (((JToken)readConfig["FlashpointPath"]).Type != JTokenType.Null)
+                    {
+                        Config.FlashpointPath = (string?)readConfig["FlashpointPath"];
+                    }
 
-                if (((JToken)readConfig["FlashpointServer"]).Type != JTokenType.Null)
-                {
-                    Config.FlashpointServer = (string?)readConfig["FlashpointServer"];
+                    if (((JToken)readConfig["CLIFpPath"]).Type != JTokenType.Null)
+                    {
+                        Config.CLIFpPath = (string?)readConfig["CLIFpPath"];
+                    }
+
+                    if (((JToken)readConfig["FlashpointServer"]).Type != JTokenType.Null)
+                    {
+                        Config.FlashpointServer = (string?)readConfig["FlashpointServer"];
+                    }
                 }
             }
         }
@@ -39,20 +42,20 @@ namespace SharpLauncher
         // Write data values to config file
         public static void Write()
         {
-            using (FileStream config = new("config.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            lock (configJsonLock)
             {
-                lock (config)
+                using (FileStream config = new("config.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
                 {
                     config.SetLength(0);
+
+                    JObject writeConfig = new();
+
+                    writeConfig["FlashpointPath"] = Config.FlashpointPath;
+                    writeConfig["CLIFpPath"] = Config.CLIFpPath;
+                    writeConfig["FlashpointServer"] = Config.FlashpointServer;
+
+                    config.Write(Encoding.ASCII.GetBytes(writeConfig.ToString()));
                 }
-
-                JObject writeConfig = new();
-
-                writeConfig["FlashpointPath"] = Config.FlashpointPath;
-                writeConfig["CLIFpPath"] = Config.CLIFpPath;
-                writeConfig["FlashpointServer"] = Config.FlashpointServer;
-
-                config.Write(Encoding.ASCII.GetBytes(writeConfig.ToString()));
             }
         }
     }

--- a/Config.cs
+++ b/Config.cs
@@ -20,13 +20,19 @@ namespace SharpLauncher
                 JObject readConfig = JObject.Parse(jsonStream.ReadToEnd());
 
                 if (((JToken)readConfig["FlashpointPath"]).Type != JTokenType.Null)
+                {
                     Config.FlashpointPath = (string?)readConfig["FlashpointPath"];
+                }
 
                 if (((JToken)readConfig["CLIFpPath"]).Type != JTokenType.Null)
+                {
                     Config.CLIFpPath = (string?)readConfig["CLIFpPath"];
+                }
 
                 if (((JToken)readConfig["FlashpointServer"]).Type != JTokenType.Null)
+                {
                     Config.FlashpointServer = (string?)readConfig["FlashpointServer"];
+                }
             }
         }
 
@@ -36,7 +42,9 @@ namespace SharpLauncher
             using (FileStream config = new("config.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
             {
                 lock (config)
+                {
                     config.SetLength(0);
+                }
 
                 JObject writeConfig = new();
 

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -6,7 +6,7 @@ namespace SharpLauncher
     public static class DBFunctions
     {
         // The size of block to read from the database.
-        public const int BlockSize = 500;
+        public const int BlockSize = 5000;
 
         // Return game or animation entries from the Flashpoint database.
         public static List<QueryItem> DatabaseQueryEntry(string query)
@@ -187,7 +187,7 @@ namespace SharpLauncher
 
         /// <summary>
         /// Gets the proper query string for a block of data, using keyset pagination to avaoid the bad performance of OFFSET.
-        /// Sorts by sortyByColumn, using Id as a secondary sort for when sortByColumn is non-uniqu.
+        /// Sorts by sortyByColumn, using Id as a secondary sort for when sortByColumn is non-unique.
         /// </summary>
         /// <param name="extraOperations">The extra conditions to put on the data.</param>
         /// <param name="lastElem">The last element of the last block, in the column sortByColumn.</param>

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Microsoft.Data.Sqlite;
-using System.Threading.Tasks;
+﻿using Microsoft.Data.Sqlite;
 
 namespace SharpLauncher
 {

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -9,13 +9,17 @@ namespace SharpLauncher
         public const int BlockSize = 5000;
 
         // Return game or animation entries from the Flashpoint database.
-        public static List<QueryItem> DatabaseQueryEntry(string query)
+        public static List<QueryItem> DatabaseQueryEntry(string query, SqliteConnection? conn = null)
         {
-            // TODO: make this persistent.
-            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
-            connection.Open();
+            bool persistentConn = true;
+            if (conn == null)
+            {
+                persistentConn = false;
+                conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+                conn.Open();
+            }
 
-            SqliteCommand command = new(query, connection);
+            SqliteCommand command = new(query, conn);
 
             List<QueryItem> data = new();
 
@@ -33,23 +37,30 @@ namespace SharpLauncher
                     });
                 }
             }
-
-            connection.Close();
+            if (!persistentConn)
+            {
+                conn.Close();
+            }
 
             return data;
         }
 
         // Return metadata about an entry from the Flashpoint database.
-        public static MetaDataObj DatabaseQueryMeta(QueryItem entry, string library = "")
+        public static MetaDataObj DatabaseQueryMeta(QueryItem entry, string library = "", SqliteConnection? conn = null)
         {
-            // TODO: make this persistent.
-            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
-            connection.Open();
+            bool persistentConn = true;
+            if (conn == null)
+            {
+                persistentConn = false;
+                conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+                conn.Open();
+            }
+            
             // Yes, I'm hard-coding this. Sue me.
             SqliteCommand command = new($"SELECT alternateTitles,series,source,releaseDate,platform,version,library,language,playMode,status,activeDataOnDisk,notes,originalDescription " +
                 $"FROM game " +
                 $"WHERE id='{entry.ID.Replace("'", "''")}' " +
-                (library == "" ? "" : $"AND library='{library.Replace("'", "''")}'"), connection);
+                (library == "" ? "" : $"AND library='{library.Replace("'", "''")}'"), conn);
             // TODO: memory leak?
             MetaDataObj data = new();
 
@@ -80,8 +91,10 @@ namespace SharpLauncher
                     };
                 }
             }
-
-            connection.Close();
+            if (!persistentConn)
+            {
+                conn.Close();
+            }
 
             return data;
         }

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -182,5 +182,12 @@ namespace SharpLauncher
 
             return String.Join(' ', queryFragments);
         }
+        // Alternate query template for favorites, play history
+        public static string GetAltQuery(string gameID, string search, List<string> extraOperations)
+        {
+            return $"SELECT title,developer,publisher,id,tagsStr FROM game WHERE id = '{gameID}'" +
+            (search != "" ? $" AND title LIKE '%{search}%'" : "") +
+            (extraOperations.Count != 0 ? " AND " + String.Join(" AND ", extraOperations) : "");
+        }
     }
 }

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -2,31 +2,48 @@
 
 namespace SharpLauncher
 {
-    // TODO: write all the documentation for this, and comment it.
     public static class DBFunctions
     {
         // The size of block to read from the database.
+        // I increased this from 500 because I was getting better performance at 5000.
         public const int BlockSize = 5000;
 
-        // Return game or animation entries from the Flashpoint database.
+        #region Database Functions
+
+        /// <summary>
+        /// Return game or animation entries from the Flashpoint database.
+        /// </summary>
+        /// <param name="query">The SQL query string to use. Must select "title,developer,publisher,id,tagsStr" in that order.</param>
+        /// <param name="conn">An open connection to the DB. If null, a new one will be created.</param>
+        /// <returns>A List of QueryItems representing the results.</returns>
         public static List<QueryItem> DatabaseQueryEntry(string query, SqliteConnection? conn = null)
         {
+            // By default, assume that we have a persistent connection.
             bool persistentConn = true;
+            // If the connection wasn't persistent,
             if (conn == null)
             {
+                // Mark it as such. We'll need this later for the Close().
                 persistentConn = false;
+                // Create and open a new connection to the db.
+                // TODO: check thread-safety on this.
                 conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
                 conn.Open();
             }
 
+            // Create a command from the query and the connection.
             SqliteCommand command = new(query, conn);
 
+            // Create a List to hold the results.
             List<QueryItem> data = new();
 
+            // The using block should handle disposes nicely.
             using (SqliteDataReader dataReader = command.ExecuteReader())
             {
+                // Repeat as long as there are lines to read.
                 while (dataReader.Read())
                 {
+                    // Add a QueryItem. Assume that the order is "title,developer,publisher,id,tagsStr"
                     data.Add(new QueryItem
                     {
                         Title = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
@@ -37,6 +54,8 @@ namespace SharpLauncher
                     });
                 }
             }
+
+            // Close the connection if we created it ourselves.
             if (!persistentConn)
             {
                 conn.Close();
@@ -44,33 +63,48 @@ namespace SharpLauncher
 
             return data;
         }
-
-        // Return metadata about an entry from the Flashpoint database.
-        public static MetaDataObj DatabaseQueryMeta(QueryItem entry, string library = "", SqliteConnection? conn = null)
+        /// <summary>
+        /// Return metadata about an entry from the Flashpoint database.
+        /// </summary>
+        /// <param name="entry">A QueryItem representing the entry in question.</param>
+        /// <param name="library">The library of the entry, if known. <i>Might</i> speed up results a bit, but no promises.</param>
+        /// <param name="conn">An open connection to the DB. If null, a new one will be created.</param>
+        /// <returns>A MetaDataObj representing the entry's metadata, or null if the entry wasn't found.</returns>
+        public static MetaDataObj? DatabaseQueryMeta(QueryItem entry, string library = "", SqliteConnection? conn = null)
         {
+            // By default, assume that we have a persistent connection.
             bool persistentConn = true;
+            // If the connection wasn't persistent,
             if (conn == null)
             {
+                // Mark it as such. We'll need this later for the Close().
                 persistentConn = false;
+                // Create and open a new connection to the db.
+                // TODO: check thread-safety on this.
                 conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
                 conn.Open();
             }
-            
+
             // Yes, I'm hard-coding this. Sue me.
+            // This gets many of the metadata fields corresponding to the entry with id=entry.ID.
+            // Note: I leave out the fields that are already supplied by the QueryItem.
             SqliteCommand command = new($"SELECT alternateTitles,series,source,releaseDate,platform,version,library,language,playMode,status,activeDataOnDisk,notes,originalDescription " +
                 $"FROM game " +
                 $"WHERE id='{entry.ID.Replace("'", "''")}' " +
                 (library == "" ? "" : $"AND library='{library.Replace("'", "''")}'"), conn);
-            // TODO: memory leak?
-            MetaDataObj data = new();
+
+            // By default, we didn't find anything. Let the result be null.
+            MetaDataObj? data = null;
 
             using (SqliteDataReader dataReader = command.ExecuteReader())
             {
+                // As long as there are lines to read (note: id should be unique, so this should run at most once):
                 while (dataReader.Read())
                 {
                     // No need for a list: this should only run once.
                     data = new MetaDataObj
                     {
+                        // Use the QueryItem fields where possible.
                         Title = entry.Title,
                         AlternateTitles = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
                         Series = dataReader.IsDBNull(1) ? "" : dataReader.GetString(1),
@@ -91,6 +125,8 @@ namespace SharpLauncher
                     };
                 }
             }
+
+            // Close the connection if we created it ourselves.
             if (!persistentConn)
             {
                 conn.Close();
@@ -99,21 +135,40 @@ namespace SharpLauncher
             return data;
         }
 
-        // Return add-app entries associated with a given parentGameId from the Flashpoint database.
-        public static List<AddApp> DatabaseQueryAddApp(string parentGameId)
+        /// <summary>
+        /// Return add-app entries associated with a given parentGameId from the Flashpoint database.
+        /// </summary>
+        /// <param name="parentGameId">The parentGameId.</param>
+        /// <param name="conn">An open connection to the DB. If null, a new one will be created.</param>
+        /// <returns>A List of AddApps representing the results.</returns>
+        public static List<AddApp> DatabaseQueryAddApp(string parentGameId, SqliteConnection? conn = null)
         {
-            // TODO: make this persistent.
-            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
-            connection.Open();
+            // By default, assume that we have a persistent connection.
+            bool persistentConn = true;
+            // If the connection wasn't persistent,
+            if (conn == null)
+            {
+                // Mark it as such. We'll need this later for the Close().
+                persistentConn = false;
+                // Create and open a new connection to the db.
+                // TODO: check thread-safety on this.
+                conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+                conn.Open();
+            }
 
-            SqliteCommand command = new($"SELECT id,name,applicationPath FROM additional_app WHERE parentGameId is '{parentGameId.Replace("'","''")}'", connection);
+            // These are the fields that AddApp has. We won't get more fields than we can populate.
+            // ParentGameId is supplied by the arguments, no need to fetch that from the db.
+            SqliteCommand command = new($"SELECT id,name,applicationPath FROM additional_app WHERE parentGameId is '{parentGameId.Replace("'","''")}'", conn);
 
+            // Make a List to hold the results.
             List<AddApp> data = new();
 
             using (SqliteDataReader dataReader = command.ExecuteReader())
             {
+                // As long as there are results to read,
                 while (dataReader.Read())
                 {
+                    // Read a row in and convert it to an AddApp object.
                     data.Add(new AddApp
                     {
                         ID = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
@@ -124,21 +179,39 @@ namespace SharpLauncher
                 }
             }
 
-            connection.Close();
+            // Close the connection if we created it ourselves.
+            if (!persistentConn)
+            {
+                conn.Close();
+            }
 
             return data;
         }
 
-        // Get the number of add-apps associated with a given gameId.
-        public static int DatabaseGetAddAppCount(string id)
+        /// <summary>
+        /// Get the number of add-apps associated with a given parentGameId.
+        /// </summary>
+        /// <param name="parentGameId">The parentGameId in question.</param>
+        /// <param name="conn">An open connection to the DB. If null, a new one will be created.</param>
+        /// <returns>The number of add-apps found in the DB that have the given parentGameId.</returns>
+        public static int DatabaseGetAddAppCount(string parentGameId, SqliteConnection? conn = null)
         {
-            // TODO: make this persistent.
-            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
-            connection.Open();
+            // By default, assume that we have a persistent connection.
+            bool persistentConn = true;
+            // If the connection wasn't persistent,
+            if (conn == null)
+            {
+                // Mark it as such. We'll need this later for the Close().
+                persistentConn = false;
+                // Create and open a new connection to the db.
+                // TODO: check thread-safety on this.
+                conn = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+                conn.Open();
+            }
 
             // Using SQL's built-in COUNT function, because I think that its performance detriments are outweighed by
             // the potential detriments of making a new list, etc.
-            SqliteCommand command = new($"SELECT COUNT(parentGameId) FROM additional_app WHERE parentGameId is '{id.Replace("'", "''")}'", connection);
+            SqliteCommand command = new($"SELECT COUNT(parentGameId) FROM additional_app WHERE parentGameId is '{parentGameId.Replace("'", "''")}'", conn);
 
             int count = 0;
 
@@ -152,49 +225,69 @@ namespace SharpLauncher
                 }
             }
 
-            connection.Close();
+            // Close the connection if we created it ourselves.
+            if (!persistentConn)
+            {
+                conn.Close();
+            }
 
             return count;
         }
 
-        // Query template to make things easier
+        #endregion
+
+        #region Query-Builder Functions
+
+        /// <summary>
+        /// Query template to make things easier. Builds a query from parameters.
+        /// </summary>
+        /// <param name="extraOperations">An array of strings, each of which is a condition to restrict the results. May be empty.</param>
+        /// <param name="search">A string that the titles of results must contain.</param>
+        /// <param name="library">The library in which the results must be.</param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
         // TODO: optimize this. Two lists created and messed with, all for one query string?
-        public static string GetQuery(List<string> extraOperations, string search = "", string library = "arcade", int offset = -1)
+        public static string GetQuery(List<string> extraOperations, string search = "", string library = "arcade")
         {
+            // We create a new List to hold the fragments of the query as we build it.
+            // Select the correct columns from the table.
             List<string> queryFragments = new() { $"SELECT title,developer,publisher,id,tagsStr FROM game" };
 
+            // If any of the conditions are active,
             if (library != "" || search != "" || extraOperations.Count != 0)
             {
+                // Add a WHERE statement.
                 queryFragments.Add("WHERE");
 
+                // Create a List to hold the conditions that will follow.
                 List<string> queryConditions = new();
 
+                // If the library is set,
                 if (library != "")
                 {
+                    // Add a condition: the library must be library.
                     // Don't rely on an unsynchronized global, instead use an argument.
                     queryConditions.Add($"library = '{library.Replace("'", "''")}'");
                 }
 
+                // If the search string is set,
                 if (search != "")
                 {
+                    // Add a condition: the title must contain search.
                     queryConditions.Add($"title LIKE '%{search.Replace("'", "''")}%'");
                 }
 
-                foreach (string operation in extraOperations)
-                {
-                    queryConditions.Add(operation);
-                }
+                // Add all conditions from extraOperations.
+                queryConditions.AddRange(extraOperations);
 
+                // Join all the conditions together with ADD statments.
                 queryFragments.Add(String.Join(" AND ", queryConditions));
             }
 
+            // We order by the title. 
             queryFragments.Add("ORDER BY title");
 
-            if (offset != -1)
-            {
-                queryFragments.Add($"LIMIT {offset}, 1");
-            }
-
+            // Join all the fragments with spaces.
             return String.Join(' ', queryFragments);
         }
 
@@ -208,51 +301,73 @@ namespace SharpLauncher
         /// <param name="sortByColumn">The column on which the keyset pagination will be performed. This column must contain only unique values.</param>
         /// <param name="sortDirection">The direction to sort. If true, sort ascending (a-z). If false, sort descending (z-a)</param>
         /// <param name="blockSize">The size of the block to query.</param>
-        /// <param name="search">The string to search for.</param>
+        /// <param name="search">The string to search titles for.</param>
         /// <param name="library">The library to search in.</param>
         /// <returns>A query string representing the block query.</returns>
         public static string GetQueryBlock(List<string> extraOperations, string lastElem = "", string lastId = "", string sortByColumn = "title", bool sortDirection = true, int blockSize = BlockSize, string search = "", string library = "arcade")
         {
+            // Depending on the sortDirection, we should have different comparison operators and terms.
+            // This one is used for comparison to the last item for keyset pagination.
             char sortOperator = sortDirection ? '>' : '<';
+            // This one is used to ensure that the results are sorted correctly - an incorrect sort
+            // would invalidate the next block, and the one after that.
             string sortTerm = sortDirection ? "ASC" : "DESC";
+
+            // We create a new List to hold the fragments of the query as we build it.
+            // Select the correct columns from the table.
             List<string> queryFragments = new() { $"SELECT title,developer,publisher,id,tagsStr FROM game" };
 
+            // If any of the conditions are active,
             if (lastElem != "" || lastId != "" || library != "" || search != "" || extraOperations.Count != 0)
             {
+                // Add a WHERE statement.
                 queryFragments.Add("WHERE");
 
+                // Create a List to hold the conditions that will follow.
                 List<string> queryConditions = new();
+
+                // If the lastElem or lastId is unset (that is, we have been passed a last element)
                 if (lastElem != "" || lastId != "")
                 {
+                    // Use keyset pagination to skip the old elements.
                     queryConditions.Add($"({sortByColumn}, id) {sortOperator} ('{lastElem.Replace("'","''")}', '{lastId.Replace("'", "''")}')");
                 }
 
+                // If the library is set,
                 if (library != "")
                 {
+                    // Add a condition: the library must be library.
                     // Don't rely on an unsynchronized global, instead use an argument.
                     queryConditions.Add($"library = '{library.Replace("'", "''")}'");
                 }
 
+                // If the search string is set,
                 if (search != "")
                 {
+                    // Add a condition: the title must contain search.
                     queryConditions.Add($"title LIKE '%{search.Replace("'", "''")}%'");
                 }
 
-                foreach (string operation in extraOperations)
-                {
-                    queryConditions.Add(operation);
-                }
+                // Add all conditions from extraOperations.
+                queryConditions.AddRange(extraOperations);
 
+                // Join all the conditions together with ADD statments.
                 queryFragments.Add(String.Join(" AND ", queryConditions));
             }
 
+            // Order by the sortByColumn primarily, in the direction sortTerm, and id secondarily, also in the direction sortTerm.
             queryFragments.Add($"ORDER BY {sortByColumn} {sortTerm}, id {sortTerm}");
 
+            // Limit our number of results to blockSize.
             queryFragments.Add($"LIMIT {blockSize}");
 
+            // Join all the fragments with spaces.
             return String.Join(' ', queryFragments);
         }
 
+        #endregion
+
+        #region Filter Functions
         /// <summary>
         /// Filter data according to filteredTags and set lastElem to the last element of data. Also set blockSize to the size of data.
         /// </summary>
@@ -290,5 +405,6 @@ namespace SharpLauncher
             (search != "" ? $" AND title LIKE '%{search}%'" : "") +
             (extraOperations.Count != 0 ? " AND " + String.Join(" AND ", extraOperations) : "");
         }
+#endregion
     }
 }

--- a/DBFunctions.cs
+++ b/DBFunctions.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Data.Sqlite;
+using System.Threading.Tasks;
+
+namespace SharpLauncher
+{
+    // TODO: write all the documentation for this, and comment it.
+    public static class DBFunctions
+    {
+
+        // Return game or animation entries from the Flashpoint database.
+        public static List<QueryItem> DatabaseQueryEntry(string query)
+        {
+            // TODO: make this persistent.
+            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+            connection.Open();
+
+            SqliteCommand command = new(query, connection);
+
+            List<QueryItem> data = new();
+
+            using (SqliteDataReader dataReader = command.ExecuteReader())
+            {
+                while (dataReader.Read())
+                {
+                    data.Add(new QueryItem
+                    {
+                        Title = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
+                        Developer = dataReader.IsDBNull(1) ? "" : dataReader.GetString(1),
+                        Publisher = dataReader.IsDBNull(2) ? "" : dataReader.GetString(2),
+                        ID = dataReader.IsDBNull(3) ? "" : dataReader.GetString(3),
+                        tagsStr = dataReader.IsDBNull(4) ? "" : dataReader.GetString(4)
+                    });
+                }
+            }
+
+            connection.Close();
+
+            return data;
+        }
+
+        // Return metadata about an entry from the Flashpoint database.
+        public static MetaDataObj DatabaseQueryMeta(QueryItem entry, string library = "")
+        {
+            // TODO: make this persistent.
+            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+            connection.Open();
+            // Yes, I'm hard-coding this. Sue me.
+            SqliteCommand command = new($"SELECT alternateTitles,series,source,releaseDate,platform,version,library,language,playMode,status,activeDataOnDisk,notes,originalDescription " +
+                $"FROM game " +
+                $"WHERE id='{entry.ID.Replace("'", "''")}' " +
+                (library == "" ? "" : $"AND library='{library.Replace("'", "''")}'"), connection);
+            // TODO: memory leak?
+            MetaDataObj data = new();
+
+            using (SqliteDataReader dataReader = command.ExecuteReader())
+            {
+                while (dataReader.Read())
+                {
+                    // No need for a list: this should only run once.
+                    data = new MetaDataObj
+                    {
+                        Title = entry.Title,
+                        AlternateTitles = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
+                        Series = dataReader.IsDBNull(1) ? "" : dataReader.GetString(1),
+                        Developer = entry.Developer,
+                        Publisher = entry.Publisher,
+                        Source = dataReader.IsDBNull(2) ? "" : dataReader.GetString(2),
+                        ReleaseDate = dataReader.IsDBNull(3) ? "" : dataReader.GetString(3),
+                        Platform = dataReader.IsDBNull(4) ? "" : dataReader.GetString(4),
+                        Version = dataReader.IsDBNull(5) ? "" : dataReader.GetString(5),
+                        Library = dataReader.IsDBNull(6) ? "" : dataReader.GetString(6),
+                        Tags = entry.tagsStr,
+                        Language = dataReader.IsDBNull(7) ? "" : dataReader.GetString(7),
+                        PlayMode = dataReader.IsDBNull(8) ? "" : dataReader.GetString(8),
+                        Status = dataReader.IsDBNull(9) ? "" : dataReader.GetString(9),
+                        Format = dataReader.IsDBNull(10) ? "" : dataReader.GetString(10),
+                        Notes = dataReader.IsDBNull(11) ? "" : dataReader.GetString(11),
+                        OriginalDescription = dataReader.IsDBNull(12) ? "" : dataReader.GetString(12)
+                    };
+                }
+            }
+
+            connection.Close();
+
+            return data;
+        }
+
+        // Return add-app entries associated with a given parentGameId from the Flashpoint database.
+        public static List<AddApp> DatabaseQueryAddApp(string parentGameId)
+        {
+            // TODO: make this persistent.
+            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+            connection.Open();
+
+            SqliteCommand command = new($"SELECT id,name,applicationPath FROM additional_app WHERE parentGameId is '{parentGameId.Replace("'","''")}'", connection);
+
+            List<AddApp> data = new();
+
+            using (SqliteDataReader dataReader = command.ExecuteReader())
+            {
+                while (dataReader.Read())
+                {
+                    data.Add(new AddApp
+                    {
+                        ID = dataReader.IsDBNull(0) ? "" : dataReader.GetString(0),
+                        ParentGameId = parentGameId,
+                        Name = dataReader.IsDBNull(1) ? "" : dataReader.GetString(1),
+                        ApplicationPath = dataReader.IsDBNull(2) ? "" : dataReader.GetString(2)
+                    });
+                }
+            }
+
+            connection.Close();
+
+            return data;
+        }
+
+        // Get the number of add-apps associated with a given gameId.
+        public static int DatabaseGetAddAppCount(string id)
+        {
+            // TODO: make this persistent.
+            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+            connection.Open();
+
+            // Using SQL's built-in COUNT function, because I think that its performance detriments are outweighed by
+            // the potential detriments of making a new list, etc.
+            SqliteCommand command = new($"SELECT COUNT(parentGameId) FROM additional_app WHERE parentGameId is '{id.Replace("'", "''")}'", connection);
+
+            int count = 0;
+
+            using (SqliteDataReader dataReader = command.ExecuteReader())
+            {
+                // This loop should run exactly once.
+                while (dataReader.Read())
+                {
+                    // The count should be in the first column.
+                    count = dataReader.GetInt32(0);
+                }
+            }
+
+            connection.Close();
+
+            return count;
+        }
+
+        // Query template to make things easier
+        // TODO: optimize this. Two lists created and messed with, all for one query string?
+        public static string GetQuery(List<string> extraOperations, string search = "", string library = "arcade", int offset = -1)
+        {
+            List<string> queryFragments = new() { $"SELECT title,developer,publisher,id,tagsStr FROM game" };
+
+            if (library != "" || search != "" || extraOperations.Count != 0)
+            {
+                queryFragments.Add("WHERE");
+
+                List<string> queryConditions = new();
+
+                if (library != "")
+                {
+                    // Don't rely on an unsynchronized global, instead use an argument.
+                    queryConditions.Add($"library = '{library.Replace("'", "''")}'");
+                }
+
+                if (search != "")
+                {
+                    queryConditions.Add($"title LIKE '%{search.Replace("'", "''")}%'");
+                }
+
+                foreach (string operation in extraOperations)
+                {
+                    queryConditions.Add(operation);
+                }
+
+                queryFragments.Add(String.Join(" AND ", queryConditions));
+            }
+
+            queryFragments.Add("ORDER BY title");
+
+            if (offset != -1)
+            {
+                queryFragments.Add($"LIMIT {offset}, 1");
+            }
+
+            return String.Join(' ', queryFragments);
+        }
+    }
+}

--- a/FPVirtualObjectListView.cs
+++ b/FPVirtualObjectListView.cs
@@ -1,0 +1,104 @@
+﻿using System.Reflection;
+using BrightIdeasSoftware;
+using static SharpLauncher.Main;
+namespace SharpLauncher
+{
+    /// <summary>
+    /// A VirtualObjectListView that creates and initializes an FPVirtualListDataSource as its VirtualListDataSource.
+    /// </summary>
+    public class FPVirtualObjectListView : VirtualObjectListView
+    {
+        public FPVirtualObjectListView()
+        {
+            // Create a new FPVirtualListDataSource for this object's VirtualListDataSource.
+            // I couldn't figure out how to do this without messing up Main.Designer.cs or making a new class,
+            // so I went with making a new class. Here we are.
+            this.VirtualListDataSource = new FPVirtualListDataSource(this);
+        }
+    }
+
+    /// <summary>
+    /// A "data source" wrapper around queryCache.
+    /// </summary>
+    /// <remarks>
+    /// Currently-implemented features:
+    /// <list type="bullet">
+    /// <item>Reading the Nth element.</item>
+    /// <item>Getting the total number of elements.</item>
+    /// <item>Sorting all the elments by a column.</item>
+    /// </list>
+    /// </remarks>
+    public class FPVirtualListDataSource : AbstractVirtualListDataSource
+    {
+        /// <summary>
+        /// Constructs one FPVirtualDataSource object. All it does right now is call the base class constructor.
+        /// </summary>
+        /// <param name="listView">The VirtualObjectListView that this is a data source for. The base class constructor needs it for some reason.</param>
+        public FPVirtualListDataSource(VirtualObjectListView listView) : base(listView)
+        {
+            // If we end up needing extra init stuff, it goes here.
+        }
+        
+        /// <summary>
+        /// Get the an object at an index from queryCache, in a thread-safe manner.
+        /// </summary>
+        /// <remarks>I declared the return type nullable, we'll see what the compiler thinks of that.</remarks>
+        /// <param name="n">The index of the object in queryCache.</param>
+        /// <returns>queryCache[n], or null if the index is out of bounds.</returns>
+        public override object GetNthObject(int n)
+        {
+            // Lock queryCache so that nobody else can access it.
+            lock (queryCacheLock)
+            {
+                // Check that the index is in-range.
+                if (n >= 0 && n < queryCache.Count)
+                {
+                    // If it is, return the object nicely.
+                    return queryCache[n];
+                }
+            }
+            // The index was out-of-range. The VirtualObjectListView will handle the null.
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the current length of queryCache in a thread-safe manner.
+        /// </summary>
+        /// <returns>queryCache.Count</returns>
+        public override int GetObjectCount()
+        {
+            // Lock queryCache so that nobody else can access it.
+            lock (queryCacheLock)
+            {
+                // As long as queryCache doesn't shrink, this should be fine.
+                // TODO: ensure that the db-refresh calls this correctly.
+                return queryCache.Count;
+            }
+        }
+
+        /// <summary>
+        /// Sorts queryCache according to column and order, in a thread-safe manner.
+        /// When there are conflicts, uses this.listView.SecondarySortColumn as a tie-breaker, with the same order.
+        /// This will be called by ArchiveList whenever the sorting arrows are pressed.
+        /// </summary>
+        /// <param name="column">The primary column to sort by.</param>
+        /// <param name="order">The order in which to sort.</param>
+        public override void Sort(OLVColumn column, SortOrder order)
+        {
+            // If the order is "unordered", don't do anything.
+            if (order != SortOrder.None)
+            {
+                // Construct a new comparer from the column, the order, and the secondary sort column.
+                // Note that we use the same order for the secondary sort column.
+                ModelObjectComparer comparer = new(column, order, this.listView.SecondarySortColumn, order);
+                // Lock queryCache so that nobody else can access it.
+                lock (queryCacheLock)
+                {
+                    // Sort queryCache according to the comparer that we just constructed.
+                    // This should be pretty efficient - quickSort, if I recall.
+                    queryCache.Sort(comparer);
+                }
+            }
+        }
+    }
+}

--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Main));
             this.ArchiveLayout = new System.Windows.Forms.TableLayoutPanel();
-            this.ArchiveList = new System.Windows.Forms.ListView();
+            this.ArchiveList = new SharpLauncher.FPVirtualObjectListView();
             this.ArchiveInfoContainer = new System.Windows.Forms.FlowLayoutPanel();
             this.ArchiveInfoTitle = new System.Windows.Forms.Label();
             this.ArchiveInfoDeveloper = new System.Windows.Forms.Label();
@@ -76,6 +76,10 @@
             this.ButtonContainer = new System.Windows.Forms.Panel();
             this.LaunchEntry = new System.Diagnostics.Process();
             this.AlternateMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.TitleColumn = new BrightIdeasSoftware.OLVColumn();
+            this.DeveloperColumn = new BrightIdeasSoftware.OLVColumn();
+            this.PublisherColumn = new BrightIdeasSoftware.OLVColumn();
+            this.IDColumn = new BrightIdeasSoftware.OLVColumn();
             this.ArchiveLayout.SuspendLayout();
             this.ArchiveInfoContainer.SuspendLayout();
             this.ArchiveImagesContainer.SuspendLayout();
@@ -119,8 +123,40 @@
             this.ArchiveLayout.Size = new System.Drawing.Size(1244, 685);
             this.ArchiveLayout.TabIndex = 3;
             // 
+            // TitleColumn
+            // 
+            this.TitleColumn.AspectName = "Title";
+            this.TitleColumn.Text = "Title";
+            // 
+            // DeveloperColumn
+            // 
+            this.DeveloperColumn.AspectName = "Developer";
+            this.DeveloperColumn.Text = "Developer";
+            // 
+            // PublisherColumn
+            // 
+            this.PublisherColumn.AspectName = "Publisher";
+            this.PublisherColumn.Text = "Publisher";
+            // 
+            // IDColumn
+            // 
+            this.IDColumn.AspectName = "ID";
+            this.IDColumn.Text = "UUID";
+            this.IDColumn.IsVisible = false;
+            this.IDColumn.Width = 0;
+            // 
             // ArchiveList
             // 
+            this.ArchiveList.AllColumns.Add(this.TitleColumn);
+            this.ArchiveList.AllColumns.Add(this.DeveloperColumn);
+            this.ArchiveList.AllColumns.Add(this.PublisherColumn);
+            this.ArchiveList.AllColumns.Add(this.IDColumn);
+            this.ArchiveList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+            this.TitleColumn,
+            this.DeveloperColumn,
+            this.PublisherColumn,
+            this.IDColumn});
+            this.ArchiveList.SecondarySortColumn = this.IDColumn;
             this.ArchiveList.AllowColumnReorder = true;
             this.ArchiveList.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ArchiveList.FullRowSelect = true;
@@ -135,10 +171,8 @@
             this.ArchiveList.UseCompatibleStateImageBehavior = false;
             this.ArchiveList.View = System.Windows.Forms.View.Details;
             this.ArchiveList.VirtualMode = true;
-            this.ArchiveList.ColumnClick += new System.Windows.Forms.ColumnClickEventHandler(this.ArchiveList_columnClick);
             this.ArchiveList.ColumnWidthChanged += new System.Windows.Forms.ColumnWidthChangedEventHandler(this.ArchiveList_columnChanged);
             this.ArchiveList.ItemActivate += new System.EventHandler(this.ArchiveList_itemAccess);
-            this.ArchiveList.RetrieveVirtualItem += new System.Windows.Forms.RetrieveVirtualItemEventHandler(this.ArchiveList_retrieveItem);
             this.ArchiveList.SelectedIndexChanged += new System.EventHandler(this.ArchiveList_itemSelect);
             this.ArchiveList.MouseMove += new System.Windows.Forms.MouseEventHandler(this.ArchiveList_mouseMove);
             // 
@@ -798,7 +832,7 @@
 
         #endregion
         private TableLayoutPanel ArchiveLayout;
-        private ListView ArchiveList;
+        private FPVirtualObjectListView ArchiveList;
         private TabControl TabControl;
         private TabPage HomeTab;
         private TabPage ArchiveTab;
@@ -843,5 +877,12 @@
         private LinkLabel HomeLinkDiscord;
         private Button RandomButton;
         private RadioButton ArchiveRadioEverything;
+        private BrightIdeasSoftware.OLVColumn TitleColumn;
+        private BrightIdeasSoftware.OLVColumn DeveloperColumn;
+        private BrightIdeasSoftware.OLVColumn PublisherColumn;
+        // Needed as the secondary sort column. Will be invisible by default.
+        private BrightIdeasSoftware.OLVColumn IDColumn;
+        // TODO: maybe add a tagsStr column? Not sure what we would use it for.
+
     }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -781,7 +781,7 @@ namespace SharpLauncher
             // TODO: slow? benchmark this.
             foreach (char inputChar in SearchBox.Text)
             {
-                if (inputChar == '\'' || inputChar == '"')
+                if (inputChar == '\'' || inputChar == '"' || inputChar == '%')
                 {
                     // Fine, but I don't like it.
                     // TODO: discuss better ways to do this.
@@ -843,11 +843,9 @@ namespace SharpLauncher
                                 {
                                     queryOperations.Add($"{operationParams[0]} LIKE '%{operationParams[1]}%'");
                                 }
-
-                                break;
                             }
                         }
-
+                        
                         // Remove brackets and everything in them.
                         tempSearch = tempSearch.Remove(leftBracket, rightBracket - leftBracket + 1);
                     }

--- a/Main.cs
+++ b/Main.cs
@@ -1,3 +1,4 @@
+using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
 using System.Diagnostics;
 using System.Text;
@@ -754,6 +755,8 @@ namespace SharpLauncher
                 }
                 else
                 {
+                    SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
+                    connection.Open();
                     // Keep going until we get back fewer than we requested: when that happens, we're at the end.
                     while (lastBlockSize == blockSize)
                     {
@@ -768,7 +771,7 @@ namespace SharpLauncher
                         lock (filterLock)
                         {
                             temp = FilterDataBlock(DatabaseQueryEntry(GetQueryBlock(qOperations, lastElem: lastItem.GetPropertyFromName(sortBy), lastId: lastItem.ID,
-                            sortByColumn: sortBy.ToLower(), sortDirection: direction == 1, blockSize: blockSize, search: qSearch, library: qLibrary)),
+                            sortByColumn: sortBy.ToLower(), sortDirection: direction == 1, blockSize: blockSize, search: qSearch, library: qLibrary), connection),
                             // Set lastItem and lastBlockSize properly.
                             tagFilters, out lastItem, out lastBlockSize);
                         }
@@ -780,11 +783,16 @@ namespace SharpLauncher
                         }
 
                     }
+                    connection.Close();
                 }
 
                 // Sort new queryCache
                 //SortColumns();
-
+                int length;
+                lock (queryCacheLock)
+                {
+                    length = queryCache.Count;
+                }
                 // Display entry count in bottom right corner
                 SetEntryCountText($"Displaying {length} entr{(length == 1 ? "y" : "ies")}.");
 

--- a/Main.cs
+++ b/Main.cs
@@ -193,7 +193,16 @@ namespace SharpLauncher
             {
                 entry = queryCache[selectedIndices[0]];
             }
-            MetaDataObj metadataOutput = DatabaseQueryMeta(entry, queryLibrary);
+
+            MetaDataObj? metadataOutput = DatabaseQueryMeta(entry, queryLibrary);
+
+            // Check: was the entry found?
+            if (metadataOutput == null)
+            {
+                // Error: the entry wasn't found in the database.
+                // Exit nicely, instead of making a mess of things.
+                return;
+            }
 
             // Header
 

--- a/Main.cs
+++ b/Main.cs
@@ -80,9 +80,13 @@ namespace SharpLauncher
             // Create data files if they don't exist, otherwise load
 
             if (File.Exists("config.json") && File.ReadAllText("config.json").Length > 0)
+            {
                 Config.Read();
+            }
             else
+            {
                 Config.Write();
+            }
 
             // Add columns to list and get width for later
 
@@ -112,9 +116,13 @@ namespace SharpLauncher
         {
             // Scale column widths to list width
             if (columnChanged)
+            {
                 ScaleColumns();
+            }
             else
+            {
                 ResetColumns();
+            }
 
             prevWidth = ArchiveList.ClientSize.Width;
 
@@ -135,14 +143,22 @@ namespace SharpLauncher
             if (((TabControl)sender).SelectedIndex == 1)
             {
                 if (Config.NeedsRefresh)
+                {
                     InitializeDatabase();
+                }
                 else if (columnChanged)
+                {
                     ScaleColumns();
+                }
                 else
+                {
                     ResetColumns();
+                }
             }
             else
+            {
                 HomeContainer.Location = GetHomepagePosition();
+            }
         }
 
         // Execute search if enter is pressed
@@ -167,7 +183,9 @@ namespace SharpLauncher
             Config.Read();
 
             if (TabControl.SelectedIndex == 1 && Config.NeedsRefresh)
+            {
                 InitializeDatabase();
+            }
         }
 
         // Display items on list when fetched
@@ -202,18 +220,17 @@ namespace SharpLauncher
             string entryID = queryCache[selectedIndices[0]].ID;
 
             for (int i = 0; i < metadataFields.Count; i++)
+            {
                 metadataOutput.Add(
                     DatabaseQuery($"SELECT {metadataFields[i][1]} from GAME where id = '{entryID}'")[0]
                 );
+            }
 
             // Header
 
             ArchiveInfoTitle.Text = metadataOutput[0];
 
-            if (metadataOutput[3] != "")
-                ArchiveInfoDeveloper.Text = $"by {metadataOutput[3]}";
-            else
-                ArchiveInfoDeveloper.Text = "by unknown developer";
+            ArchiveInfoDeveloper.Text = metadataOutput[3] != "" ? $"by {metadataOutput[3]}" : "by unknown developer";
 
             ArchiveInfoData.Height = GetInfoHeight();
 
@@ -222,7 +239,9 @@ namespace SharpLauncher
             string entryData = @"{\rtf1 ";
 
             for (int i = 1; i < metadataOutput.Count; i++)
+            {
                 if (metadataOutput[i] != "")
+                {
                     switch (metadataFields[i][0])
                     {
                         case "Library":
@@ -245,6 +264,8 @@ namespace SharpLauncher
                             entryData += $"\\b {metadataFields[i][0]}: \\b0 {ToUnicode(metadataOutput[i])}\\line";
                             break;
                     }
+                }
+            }
 
             entryData += "}";
 
@@ -253,8 +274,10 @@ namespace SharpLauncher
             // Images
 
             if (!ArchiveImagesContainer.Visible)
+            {
                 ArchiveImagesContainer.Visible = true;
-            
+            }
+
             foreach (string folder in new string[] { "Logos", "Screenshots" })
             {
                 string[] imageTree = { entryID.Substring(0, 2), entryID.Substring(2, 2) };
@@ -276,9 +299,13 @@ namespace SharpLauncher
                 else
                 {
                     if (folder == "Logos")
+                    {
                         ArchiveImagesLogo.ImageLocation = Config.FlashpointServer + imagePath;
+                    }
                     else if (folder == "Screenshots")
+                    {
                         ArchiveImagesScreenshot.ImageLocation = Config.FlashpointServer + imagePath;
+                    }
                 }
             }
 
@@ -316,7 +343,9 @@ namespace SharpLauncher
         private void ArchiveList_itemAccess(object sender, EventArgs e)
         {
             if (!InitializeCLIFp())
+            {
                 return;
+            }
 
             string entryID = queryCache[ArchiveList.SelectedIndices[0]].ID;
 
@@ -359,7 +388,9 @@ namespace SharpLauncher
         private void AlternateMenu_itemClicked(object sender, ToolStripItemClickedEventArgs e)
         {
             if (!InitializeCLIFp())
+            {
                 return;
+            }
 
             string entryID = (string)e.ClickedItem.Tag;
             string entryAppPath = DatabaseQuery($"SELECT applicationPath FROM additional_app WHERE id = '{entryID}'")[0];
@@ -394,14 +425,18 @@ namespace SharpLauncher
             if (favoriteButton.Checked)
             {
                 if (!favoritedEntries.Contains(entryID))
+                {
                     favoritedEntries.Add(entryID);
+                }
 
                 favoriteButton.ImageIndex = 1;
             }
             else
             {
                 if (favoritedEntries.Contains(entryID))
+                {
                     favoritedEntries.Remove(entryID);
+                }
 
                 favoriteButton.ImageIndex = 0;
             }
@@ -428,8 +463,12 @@ namespace SharpLauncher
 
             // Remove any indicators that might be visible
             for (int i = 0; i < columnHeaders.Length; i++)
+            {
                 if (ArchiveList.Columns[i].Text != columnHeaders[i])
+                {
                     ArchiveList.Columns[i].Text = columnHeaders[i];
+                }
+            }
 
             // Add a new arrow indicator to column header
             string arrow = char.ConvertFromUtf32(0x2192 + queryDirection);
@@ -453,7 +492,9 @@ namespace SharpLauncher
         private void RandomButton_Click(object sender, EventArgs e)
         {
             if (ArchiveList.VirtualListSize == 0)
+            {
                 return;
+            }
 
             int randomEntryIndex = rng.Next(ArchiveList.VirtualListSize);
 
@@ -470,7 +511,9 @@ namespace SharpLauncher
             activateOnce = !activateOnce;
 
             if (!activateOnce)
+            {
                 return;
+            }
 
             RadioButton checkedRadio = (RadioButton)sender;
 
@@ -492,12 +535,18 @@ namespace SharpLauncher
 
                     case "ArchiveRadioPlays":
                         if (File.Exists("downloads.fp") && playedEntries.Count == 0)
+                        {
                             playedEntries = File.ReadAllLines("downloads.fp").ToList();
+                        }
+
                         break;
 
                     case "ArchiveRadioFavorites":
                         if (File.Exists("favorites.fp") && favoritedEntries.Count == 0)
+                        {
                             favoritedEntries = File.ReadAllLines("favorites.fp").ToList();
+                        }
+
                         break;
                 }
 
@@ -508,9 +557,13 @@ namespace SharpLauncher
         private void ArchiveImages_loadCompleted(object sender, System.ComponentModel.AsyncCompletedEventArgs e)
         {
             if (((PictureBox)sender).Name == "ArchiveImagesLogo")
+            {
                 logoLoaded = true;
+            }
             else if (((PictureBox)sender).Name == "ArchiveImagesScreenshot")
+            {
                 screenshotLoaded = true;
+            }
         }
 
         // Display picture viwwer 
@@ -549,7 +602,9 @@ namespace SharpLauncher
         private void InitializeDatabase()
         {
             if (Config.NeedsRefresh)
+            {
                 Config.NeedsRefresh = false;
+            }
 
             string databasePath = Config.FlashpointPath + @"\Data\flashpoint.sqlite";
             byte[] header = new byte[16];
@@ -557,7 +612,9 @@ namespace SharpLauncher
             if (File.Exists(databasePath))
             {
                 using (FileStream fileStream = new(databasePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
                     fileStream.Read(header, 0, 16);
+                }
 
                 if (Encoding.ASCII.GetString(header).Contains("SQLite format"))
                 {
@@ -598,7 +655,9 @@ namespace SharpLauncher
                 foreach (string id in ArchiveRadioPlays.Checked ? playedEntries : favoritedEntries)
                 {
                     if (DatabaseQuery($"SELECT id FROM game WHERE id = '{id}'").Count == 0)
+                    {
                         continue;
+                    }
 
                     // Alternate query template for favorites, play history
                     string GetAltQuery(string column) =>
@@ -627,7 +686,9 @@ namespace SharpLauncher
 
             // If item is not filtered, create QueryItem object and add to queryCache
             for (int i = 0; i < queryTitle.Count; i++)
+            {
                 if (!filteredTags.Intersect(queryTags[i].Split("; ")).Any())
+                {
                     queryCache.Add(new QueryItem
                     {
                         Title = queryTitle[i],
@@ -635,6 +696,8 @@ namespace SharpLauncher
                         Publisher = queryPublisher[i],
                         ID = queryID[i]
                     });
+                }
+            }
 
             // Sort new queryCache
             SortColumns();
@@ -648,9 +711,13 @@ namespace SharpLauncher
 
             // Prevent column widths from breaking out of list
             if (columnChanged)
+            {
                 ScaleColumns();
+            }
             else
+            {
                 ResetColumns();
+            }
         }
 
         private bool InitializeCLIFp()
@@ -679,16 +746,24 @@ namespace SharpLauncher
                     dynamic? filterArray = JsonConvert.DeserializeObject(jsonStream.ReadToEnd());
 
                     foreach (var item in filterArray)
+                    {
                         if (item.filtered == true)
+                        {
                             foreach (var tag in item.tags)
+                            {
                                 filteredTags.Add(tag.ToString());
+                            }
+                        }
+                    }
                 }
             }
             else
+            {
                 MessageBox.Show(
                     "filters.json was not found, and as a result the archive will be unfiltered. Use at your own risk.",
                     "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning
                 );
+            }
         }
 
         // Handle read/write from .fp files
@@ -696,13 +771,17 @@ namespace SharpLauncher
         private void EnsurePlaysLoaded()
         {
             if (File.Exists("downloads.fp") && playedEntries.Count == 0)
+            {
                 playedEntries = File.ReadAllLines("downloads.fp").ToList();
+            }
         }
 
         private void EnsureFavoritesLoaded()
         {
             if (File.Exists("favorites.fp") && favoritedEntries.Count == 0)
+            {
                 favoritedEntries = File.ReadAllLines("favorites.fp").ToList();
+            }
         }
 
         private void UpdateListFile(string fileName, List<string> list)
@@ -710,7 +789,9 @@ namespace SharpLauncher
             using (FileStream file = new(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
             {
                 lock (file)
+                {
                     file.SetLength(0);
+                }
 
                 file.Write(Encoding.ASCII.GetBytes(String.Join(Environment.NewLine, list)));
             }
@@ -727,8 +808,12 @@ namespace SharpLauncher
             List<string> data = new();
 
             using (SqliteDataReader dataReader = command.ExecuteReader())
+            {
                 while (dataReader.Read())
+                {
                     data.Add(dataReader.IsDBNull(0) ? "" : dataReader.GetString(0));
+                }
+            }
 
             connection.Close();
 
@@ -747,11 +832,19 @@ namespace SharpLauncher
                 List<string> queryConditions = new();
 
                 if (queryLibrary != "")
+                {
                     queryConditions.Add($"library = '{queryLibrary}'");
+                }
+
                 if (querySearch != "")
+                {
                     queryConditions.Add($"title LIKE '%{querySearch}%'");
+                }
+
                 foreach (string operation in queryOperations)
+                {
                     queryConditions.Add(operation);
+                }
 
                 queryFragments.Add(String.Join(" AND ", queryConditions));
             }
@@ -759,7 +852,9 @@ namespace SharpLauncher
             queryFragments.Add("ORDER BY title");
 
             if (offset != -1)
+            {
                 queryFragments.Add($"LIMIT {offset}, 1");
+            }
 
             return String.Join(' ', queryFragments);
         }
@@ -774,9 +869,13 @@ namespace SharpLauncher
             foreach (char inputChar in SearchBox.Text)
             {
                 if (inputChar == '\'' || inputChar == '"')
+                {
                     safeQuery.Append('_');
+                }
                 else
+                {
                     safeQuery.Append(inputChar);
+                }
             }
 
             string tempSearch = safeQuery.ToString();
@@ -804,7 +903,9 @@ namespace SharpLauncher
 
                         // Create operation if parameters are valid
                         if (operationParams.Length == 2)
+                        {
                             foreach (string[] field in metadataFields)
+                            {
                                 if (operationParams[0] == field[1])
                                 {
                                     string[] operationValues = operationParams[1].Split("|");
@@ -815,15 +916,21 @@ namespace SharpLauncher
                                         List<string> queryOr = new();
 
                                         foreach (string value in operationValues)
+                                        {
                                             queryOr.Add($"{operationParams[0]} LIKE '{value}'");
+                                        }
 
                                         queryOperations.Add($"({String.Join(" OR ", queryOr)})");
                                     }
                                     else
+                                    {
                                         queryOperations.Add($"{operationParams[0]} LIKE '{operationParams[1]}'");
+                                    }
 
                                     break;
                                 }
+                            }
+                        }
 
                         // Remove brackets
                         tempSearch = tempSearch.Remove(leftBracket, rightBracket - leftBracket + 1);
@@ -833,9 +940,14 @@ namespace SharpLauncher
 
             // Remove padding
             while (tempSearch.Length > 0 && tempSearch[0] == ' ')
+            {
                 tempSearch = tempSearch.Remove(0, 1);
+            }
+
             while (tempSearch.Length > 0 && tempSearch[tempSearch.Length - 1] == ' ')
+            {
                 tempSearch = tempSearch.Remove(tempSearch.Length - 1);
+            }
 
             // Apply remaining string to generic search query
             querySearch = tempSearch;
@@ -878,7 +990,9 @@ namespace SharpLauncher
             ArchiveList.EndUpdate();
 
             if (columnChanged)
+            {
                 columnChanged = false;
+            }
         }
 
         // Sort items by a specific column
@@ -927,8 +1041,12 @@ namespace SharpLauncher
             int desiredHeight = ArchiveInfoContainer.Height - 14;
 
             foreach (Control control in ArchiveInfoContainer.Controls)
+            {
                 if (control.Name != "ArchiveInfoData")
+                {
                     desiredHeight -= control.Height;
+                }
+            }
 
             return desiredHeight;
         }
@@ -956,11 +1074,17 @@ namespace SharpLauncher
             foreach (char c in data)
             {
                 if (c == '\\' || c == '{' || c == '}')
+                {
                     escapedData.Append(@"\" + c);
+                }
                 else if (c <= 0x7f)
+                {
                     escapedData.Append(c);
+                }
                 else
+                {
                     escapedData.Append(@"\u" + Convert.ToUInt32(c) + "?");
+                }
             }
 
             return escapedData.ToString().Replace("\n", @"\line ");

--- a/Main.cs
+++ b/Main.cs
@@ -691,16 +691,7 @@ namespace SharpLauncher
                 List<QueryItem> temp;
                 QueryItem lastItem = new();
                 int lastBlockSize = blockSize;
-                // queryCache.Count, but without the need for locking.
-                // Scale the columns nicely.
-                if (colChanged)
-                {
-                    ScaleColumns();
-                }
-                else
-                {
-                    ResetColumns();
-                }
+                
                 // Get values to be inserted into QueryItem objects
                 if (playsChecked || favoritesChecked)
                 {
@@ -722,13 +713,21 @@ namespace SharpLauncher
                     SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
                     connection.Open();
                     // Keep going until we get back fewer than we requested: when that happens, we're at the end.
-                    while (lastBlockSize == blockSize)
+                    // Ooh, look at me being clever. For-loops can have arbitrary conditions. This is a while-loop, but with a loop counter.
+                    for (int iterationNum=0; lastBlockSize == blockSize; iterationNum++)
                     {
-                        // If we haven't yet displayed the first page and we have enough results to do so, do it.
-                        if (true)//(!pastFirstPage && length >= blockSize)
+                        // Update the columns after the first block is done.
+                        if (iterationNum == 1)
                         {
-                            // Set the list length appropriately.
-                            UpdateArchiveListLength();
+                            // Scale the columns nicely.
+                            if (colChanged)
+                            {
+                                ScaleColumns();
+                            }
+                            else
+                            {
+                                ResetColumns();
+                            }
                         }
 
                         // Query the DB for one block.
@@ -745,6 +744,8 @@ namespace SharpLauncher
                         {
                             queryCache.AddRange(temp);
                         }
+                        // Set the list length appropriately.
+                        UpdateArchiveListLength();
 
                     }
                     connection.Close();

--- a/Main.cs
+++ b/Main.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
+using static SharpLauncher.DBFunctions;
 
 namespace SharpLauncher
 {
@@ -18,27 +19,8 @@ namespace SharpLauncher
 
         // Previous width of the list
         int prevWidth;
-        // Metadata fields to be retrieved alongside their proper names
-        List<string[]> metadataFields = new()
-        {
-            new[] { "Title", "title" },
-            new[] { "Alternate Titles", "alternateTitles" },
-            new[] { "Series", "series" },
-            new[] { "Developer", "developer" },
-            new[] { "Publisher", "publisher" },
-            new[] { "Source", "source" },
-            new[] { "Release Date", "releaseDate" },
-            new[] { "Platform", "platform" },
-            new[] { "Version", "version" },
-            new[] { "Library", "library" },
-            new[] { "Tags", "tagsStr" },
-            new[] { "Language", "language" },
-            new[] { "Play Mode", "playMode" },
-            new[] { "Status", "status" },
-            new[] { "Format", "activeDataOnDisk" },
-            new[] { "Notes", "notes" },
-            new[] { "Original Description", "originalDescription" }
-        };
+        
+        
         // Titles to be displayed above each column
         string[] columnHeaders = { "Title", "Developer", "Publisher" };
         // Calculated column widths before conversion to int
@@ -51,16 +33,13 @@ namespace SharpLauncher
         int queryDirection = 1;
         string querySearch = "";
         List<string> queryOperations = new();
-        // Template for list items
-        class QueryItem
-        {
-            public string Title { get; set; } = "";
-            public string Developer { get; set; } = "";
-            public string Publisher { get; set; } = "";
-            public string ID { get; set; } = "";
-        }
+        
         // Cache of all items to be displayed in list
         List<QueryItem> queryCache = new();
+        // An object for locking access to the queryCache between threads.
+        readonly object queryCacheLock = new object();
+        // A ManualResetEvent that the main thread should wait on until the queryCache is ready for reading.
+        ManualResetEventSlim queryCacheWH = new(true);
         // Array of all entries that have been played
         List<string> playedEntries = new();
         // Array of all entries that have been favorited
@@ -144,6 +123,7 @@ namespace SharpLauncher
             {
                 if (Config.NeedsRefresh)
                 {
+                    // TODO: Move this.
                     InitializeDatabase();
                 }
                 else if (columnChanged)
@@ -216,60 +196,20 @@ namespace SharpLauncher
                 return;
             }
 
-            List<string> metadataOutput = new(metadataFields.Count);
-            string entryID = queryCache[selectedIndices[0]].ID;
-
-            for (int i = 0; i < metadataFields.Count; i++)
-            {
-                metadataOutput.Add(
-                    DatabaseQuery($"SELECT {metadataFields[i][1]} from GAME where id = '{entryID}'")[0]
-                );
-            }
+            
+            QueryItem entry = queryCache[selectedIndices[0]];
+            MetaDataObj metadataOutput = DatabaseQueryMeta(entry, queryLibrary);
 
             // Header
 
-            ArchiveInfoTitle.Text = metadataOutput[0];
+            ArchiveInfoTitle.Text = metadataOutput.Title;
 
-            ArchiveInfoDeveloper.Text = metadataOutput[3] != "" ? $"by {metadataOutput[3]}" : "by unknown developer";
+            ArchiveInfoDeveloper.Text = metadataOutput.Developer != "" ? $"by {metadataOutput.Developer}" : "by unknown developer";
 
             ArchiveInfoData.Height = GetInfoHeight();
 
             // Metadata
-
-            string entryData = @"{\rtf1 ";
-
-            for (int i = 1; i < metadataOutput.Count; i++)
-            {
-                if (metadataOutput[i] != "")
-                {
-                    switch (metadataFields[i][0])
-                    {
-                        case "Library":
-                            entryData +=
-                                $"\\b {metadataFields[i][0]}: \\b0 " +
-                                ToUnicode(metadataOutput[i][0].ToString().ToUpper() + metadataOutput[i][1..]) +
-                                "\\line";
-                            break;
-
-                        case "Format":
-                            entryData += $"\\b {metadataFields[i][0]}: \\b0 {(metadataOutput[i] == "0" ? "Legacy" : "GameZIP")}\\line";
-                            break;
-
-                        case "Notes":
-                        case "Original Description":
-                            entryData += $"\\line\\b {metadataFields[i][0]}:\\line\\b0 {ToUnicode(metadataOutput[i])}\\line";
-                            break;
-
-                        default:
-                            entryData += $"\\b {metadataFields[i][0]}: \\b0 {ToUnicode(metadataOutput[i])}\\line";
-                            break;
-                    }
-                }
-            }
-
-            entryData += "}";
-
-            ArchiveInfoData.Rtf = entryData;
+            ArchiveInfoData.Rtf = BuildEntryData(metadataOutput);
 
             // Images
 
@@ -280,8 +220,8 @@ namespace SharpLauncher
 
             foreach (string folder in new string[] { "Logos", "Screenshots" })
             {
-                string[] imageTree = { entryID.Substring(0, 2), entryID.Substring(2, 2) };
-                string imagePath = $"\\Data\\Images\\{folder}\\{imageTree[0]}\\{imageTree[1]}\\{entryID}.png";
+                string[] imageTree = { entry.ID.Substring(0, 2), entry.ID.Substring(2, 2) };
+                string imagePath = $"\\Data\\Images\\{folder}\\{imageTree[0]}\\{imageTree[1]}\\{entry.ID}.png";
 
                 if (File.Exists(Config.FlashpointPath + imagePath))
                 {
@@ -311,10 +251,8 @@ namespace SharpLauncher
 
             // Footer
 
-            List<string> additionalApps = DatabaseQuery($"SELECT name FROM additional_app WHERE parentGameId = '{entryID}'");
-
             // Display or hide additional apps button if they exist
-            if (additionalApps.Count > 0)
+            if (DatabaseGetAddAppCount(entry.ID) > 0)
             {
                 PlayButton.Width = 238;
                 AlternateButton.Visible = true;
@@ -337,6 +275,51 @@ namespace SharpLauncher
             }
 
             PlayContainer.Visible = true;
+        }
+
+        /// <summary>
+        /// Builds the string to display in the panel from a metadata input.
+        /// </summary>
+        /// <param name="meta">The metadata object describing the selected game.</param>
+        /// <returns>The RTF display string.</returns>
+        private static string BuildEntryData(MetaDataObj meta)
+        {
+            string entryData = @"{\rtf1 ";
+            entryData += meta.AlternateTitles == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["alternateTitles"]}: \\b0 {ToUnicode(meta.AlternateTitles)}\\line";
+            entryData += meta.Series == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["series"]}: \\b0 {ToUnicode(meta.Series)}\\line";
+            entryData += meta.Developer == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["developer"]}: \\b0 {ToUnicode(meta.Developer)}\\line";
+            entryData += meta.Publisher == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["publisher"]}: \\b0 {ToUnicode(meta.Publisher)}\\line";
+            entryData += meta.Source == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["source"]}: \\b0 {ToUnicode(meta.Source)}\\line";
+            entryData += meta.ReleaseDate == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["releaseDate"]}: \\b0 {ToUnicode(meta.ReleaseDate)}\\line";
+            entryData += meta.Platform == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["platform"]}: \\b0 {ToUnicode(meta.Platform)}\\line";
+            entryData += meta.Version == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["version"]}: \\b0 {ToUnicode(meta.Version)}\\line";
+            entryData += meta.Library == "" ? "" : $"\\b {MetaDataObj.metadataFields["library"]}: \\b0 " +
+                                ToUnicode(meta.Library[0].ToString().ToUpper() + meta.Library[1..]) +
+                                "\\line";
+            entryData += meta.Tags == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["tagsStr"]}: \\b0 {ToUnicode(meta.Tags)}\\line";
+            entryData += meta.Language == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["language"]}: \\b0 {ToUnicode(meta.Language)}\\line";
+            entryData += meta.PlayMode == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["playMode"]}: \\b0 {ToUnicode(meta.PlayMode)}\\line";
+            entryData += meta.Status == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["status"]}: \\b0 {ToUnicode(meta.Status)}\\line";
+            entryData += meta.Format == "" ? "" :
+                $"\\b {MetaDataObj.metadataFields["activeDataOnDisk"]}: \\b0 {(meta.Format == "0" ? "Legacy" : "GameZIP")}\\line";
+            entryData += meta.Notes == "" ? "" :
+                $"\\line\\b {MetaDataObj.metadataFields["notes"]}:\\line\\b0 {ToUnicode(meta.Notes)}\\line";
+            entryData += meta.OriginalDescription == "" ? "" :
+                $"\\line\\b {MetaDataObj.metadataFields["originalDescription"]}:\\line\\b0 {ToUnicode(meta.OriginalDescription)}\\line";
+            entryData += "}";
+            return entryData;
         }
 
         // Launch selected entry
@@ -370,10 +353,10 @@ namespace SharpLauncher
             string entryID = queryCache[ArchiveList.SelectedIndices[0]].ID;
 
             int i = 0;
-            foreach (string id in DatabaseQuery($"SELECT id FROM additional_app WHERE parentGameId = '{entryID}'"))
+            foreach (AddApp entry in DatabaseQueryAddApp(entryID))
             {
-                AlternateMenu.Items.Add($"Launch: " + DatabaseQuery($"SELECT name FROM additional_app WHERE id = '{id}'")[0]);
-                AlternateMenu.Items[i].Tag = id;
+                AlternateMenu.Items.Add($"Launch: " + entry.Name);
+                AlternateMenu.Items[i].Tag = entry;
 
                 i++;
             }
@@ -392,19 +375,17 @@ namespace SharpLauncher
                 return;
             }
 
-            string entryID = (string)e.ClickedItem.Tag;
-            string entryAppPath = DatabaseQuery($"SELECT applicationPath FROM additional_app WHERE id = '{entryID}'")[0];
+            AddApp entry = (AddApp)e.ClickedItem.Tag;
 
-            LaunchEntry.StartInfo.Arguments = $"play -i {entryID}";
+            LaunchEntry.StartInfo.Arguments = $"play -i {entry.ID}";
 
-            if (entryAppPath != ":extras:" && entryAppPath != ":message:")
+            if (entry.ApplicationPath != ":extras:" && entry.ApplicationPath != ":message:")
             {
-                string entryParentID = DatabaseQuery($"SELECT parentGameId FROM additional_app WHERE id = '{entryID}'")[0];
 
                 // Add to list of played entries (if it hasn't been played already)
-                if (!playedEntries.Contains(entryParentID))
+                if (!playedEntries.Contains(entry.ParentGameId))
                 {
-                    playedEntries.Add(entryParentID);
+                    playedEntries.Add(entry.ParentGameId);
 
                     UpdateListFile("downloads.fp", playedEntries);
                 }
@@ -638,6 +619,7 @@ namespace SharpLauncher
         }
 
         // Generate new cache and refresh list
+        // TODO: make this into a thread wrapper-func.
         private void RefreshDatabase()
         {
             ClearInfoPanel();
@@ -648,54 +630,44 @@ namespace SharpLauncher
             List<string> queryPublisher = new();
             List<string> queryTags = new();
             List<string> queryID = new();
+            List<QueryItem> temp;
 
             // Get values to be inserted into QueryItem objects
             if (ArchiveRadioPlays.Checked || ArchiveRadioFavorites.Checked)
             {
+                temp = new();
                 foreach (string id in ArchiveRadioPlays.Checked ? playedEntries : favoritedEntries)
                 {
-                    if (DatabaseQuery($"SELECT id FROM game WHERE id = '{id}'").Count == 0)
+                    // TODO: disable this, and ask Wumbo why it's here. We shouldn't have invalid IDs.
+                    /*if (DatabaseQuery($"SELECT id FROM game WHERE id = '{id}'").Count == 0)
                     {
                         continue;
-                    }
+                    }*/
 
                     // Alternate query template for favorites, play history
-                    string GetAltQuery(string column) =>
-                        $"SELECT {column} FROM game WHERE id = '{id}'" +
-                        (querySearch != "" ? $" AND title LIKE '%{querySearch}%'" : "") +
-                        (queryOperations.Count != 0 ? " AND " + String.Join(" AND ", queryOperations) : "");
-
-                    if (DatabaseQuery(GetAltQuery("title")).Count > 0)
-                    {
-                        queryTitle.Add(DatabaseQuery(GetAltQuery("title"))[0]);
-                        queryDeveloper.Add(DatabaseQuery(GetAltQuery("developer"))[0]);
-                        queryPublisher.Add(DatabaseQuery(GetAltQuery("publisher"))[0]);
-                        queryTags.Add(DatabaseQuery(GetAltQuery("tagsStr"))[0]);
-                        queryID.Add(id);
-                    }
+                    string GetAltQuery(string gameID, string search, List<string> extraOperations) =>
+                        $"SELECT title,developer,publisher,id,tagsStr FROM game WHERE id = '{gameID}'" +
+                        (search != "" ? $" AND title LIKE '%{search}%'" : "") +
+                        (extraOperations.Count != 0 ? " AND " + String.Join(" AND ", extraOperations) : "");
+                    // TODO: make one enormous list of OR'd conditions, so that we don't end up with hundreds of separate
+                    // queries, when we could have one large one.
+                    temp.AddRange(DatabaseQueryEntry(GetAltQuery(id, querySearch, queryOperations)));
                 }
             }
             else
             {
-                queryTitle = DatabaseQuery(GetQuery("title"));
-                queryDeveloper = DatabaseQuery(GetQuery("developer"));
-                queryPublisher = DatabaseQuery(GetQuery("publisher"));
-                queryTags = DatabaseQuery(GetQuery("tagsStr"));
-                queryID = DatabaseQuery(GetQuery("id"));
+                temp = DatabaseQueryEntry(GetQuery(queryOperations, querySearch, queryLibrary));
             }
 
             // If item is not filtered, create QueryItem object and add to queryCache
-            for (int i = 0; i < queryTitle.Count; i++)
+            for (int i = 0; i < temp.Count; i++)
             {
-                if (!filteredTags.Intersect(queryTags[i].Split("; ")).Any())
+                if (!filteredTags.Intersect(temp[i].tagsStr.Split("; ")).Any())
                 {
-                    queryCache.Add(new QueryItem
+                    lock (queryCacheLock)
                     {
-                        Title = queryTitle[i],
-                        Developer = queryDeveloper[i],
-                        Publisher = queryPublisher[i],
-                        ID = queryID[i]
-                    });
+                        queryCache.Add(temp[i]);
+                    }
                 }
             }
 
@@ -788,6 +760,7 @@ namespace SharpLauncher
         {
             using (FileStream file = new(fileName, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite))
             {
+                // TODO: wtf is this?
                 lock (file)
                 {
                     file.SetLength(0);
@@ -796,80 +769,22 @@ namespace SharpLauncher
                 file.Write(Encoding.ASCII.GetBytes(String.Join(Environment.NewLine, list)));
             }
         }
-
-        // Return items from the Flashpoint database
-        private List<string> DatabaseQuery(string query)
-        {
-            SqliteConnection connection = new($"Data Source={Config.FlashpointPath}\\Data\\flashpoint.sqlite");
-            connection.Open();
-
-            SqliteCommand command = new(query, connection);
-
-            List<string> data = new();
-
-            using (SqliteDataReader dataReader = command.ExecuteReader())
-            {
-                while (dataReader.Read())
-                {
-                    data.Add(dataReader.IsDBNull(0) ? "" : dataReader.GetString(0));
-                }
-            }
-
-            connection.Close();
-
-            return data;
-        }
-
-        // Query template to make things easier
-        private string GetQuery(string column, int offset = -1)
-        {
-            List<string> queryFragments = new() { $"SELECT {column} FROM game" };
-
-            if (queryLibrary != "" || querySearch != "" || queryOperations.Count != 0)
-            {
-                queryFragments.Add("WHERE");
-
-                List<string> queryConditions = new();
-
-                if (queryLibrary != "")
-                {
-                    queryConditions.Add($"library = '{queryLibrary}'");
-                }
-
-                if (querySearch != "")
-                {
-                    queryConditions.Add($"title LIKE '%{querySearch}%'");
-                }
-
-                foreach (string operation in queryOperations)
-                {
-                    queryConditions.Add(operation);
-                }
-
-                queryFragments.Add(String.Join(" AND ", queryConditions));
-            }
-
-            queryFragments.Add("ORDER BY title");
-
-            if (offset != -1)
-            {
-                queryFragments.Add($"LIMIT {offset}, 1");
-            }
-
-            return String.Join(' ', queryFragments);
-        }
-
+        // TODO: mess with this, ensure it escapes stuff properly.
         private void ExecuteSearchQuery()
         {
+            // TODO: memory leak
             queryOperations = new();
 
             StringBuilder safeQuery = new();
 
             // Replace unsafe characters
+            // TODO: slow? benchmark this.
             foreach (char inputChar in SearchBox.Text)
             {
                 if (inputChar == '\'' || inputChar == '"')
                 {
+                    // Fine, but I don't like it.
+                    // TODO: discuss better ways to do this.
                     safeQuery.Append('_');
                 }
                 else
@@ -891,12 +806,13 @@ namespace SharpLauncher
                 // Iterate through each group of brackets
                 for (int i = 0; i < leftBracketCount; i++)
                 {
-                    // Get indexes of brackets
+                    // Get indicies of brackets
+                    // HACK: because this doesn't correctly deal with nested brackets.
                     int leftBracket = tempSearch.IndexOf('[');
                     int rightBracket = tempSearch.IndexOf(']');
 
                     // Check if brackets are formatted correctly
-                    if (rightBracket > leftBracket)
+                    if (rightBracket > leftBracket && leftBracket != -1)
                     {
                         // Get array containing each parameter
                         string[] operationParams = tempSearch.Substring(leftBracket + 1, rightBracket - leftBracket - 1).Split(':');
@@ -904,51 +820,43 @@ namespace SharpLauncher
                         // Create operation if parameters are valid
                         if (operationParams.Length == 2)
                         {
-                            foreach (string[] field in metadataFields)
+                            // TODO: aliases of meta names.
+                            if (MetaDataObj.metadataFields.ContainsKey(operationParams[0]))
                             {
-                                if (operationParams[0] == field[1])
+                                
+
+                                // Check for OR | operators and update query accordingly
+                                if (operationParams[1].Contains('|'))
                                 {
+                                    // TODO: make this efficient. How many lists are we using?
                                     string[] operationValues = operationParams[1].Split("|");
+                                    List<string> queryOr = new();
 
-                                    // Check for OR | operators and update query accordingly
-                                    if (operationValues.Length > 1)
+                                    foreach (string value in operationValues)
                                     {
-                                        List<string> queryOr = new();
-
-                                        foreach (string value in operationValues)
-                                        {
-                                            queryOr.Add($"{operationParams[0]} LIKE '{value}'");
-                                        }
-
-                                        queryOperations.Add($"({String.Join(" OR ", queryOr)})");
-                                    }
-                                    else
-                                    {
-                                        queryOperations.Add($"{operationParams[0]} LIKE '{operationParams[1]}'");
+                                        queryOr.Add($"{operationParams[0]} LIKE '%{value}%'");
                                     }
 
-                                    break;
+                                    queryOperations.Add($"({string.Join(" OR ", queryOr)})");
                                 }
+                                else
+                                {
+                                    queryOperations.Add($"{operationParams[0]} LIKE '%{operationParams[1]}%'");
+                                }
+
+                                break;
                             }
                         }
 
-                        // Remove brackets
+                        // Remove brackets and everything in them.
                         tempSearch = tempSearch.Remove(leftBracket, rightBracket - leftBracket + 1);
                     }
                 }
             }
 
             // Remove padding
-            while (tempSearch.Length > 0 && tempSearch[0] == ' ')
-            {
-                tempSearch = tempSearch.Remove(0, 1);
-            }
-
-            while (tempSearch.Length > 0 && tempSearch[tempSearch.Length - 1] == ' ')
-            {
-                tempSearch = tempSearch.Remove(tempSearch.Length - 1);
-            }
-
+            tempSearch = tempSearch.Trim();
+            
             // Apply remaining string to generic search query
             querySearch = tempSearch;
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -7,6 +7,8 @@ namespace SharpLauncher
 {
     public partial class Settings : Form
     {
+
+        public static readonly object filterLock = new();
         // String copy of filters.json
         private string filterJSON = "";
 
@@ -23,19 +25,22 @@ namespace SharpLauncher
             // Load tag filters
             if (File.Exists("filters.json"))
             {
-                using (StreamReader jsonStream = new("filters.json"))
+                lock (filterLock)
                 {
-                    filterJSON = jsonStream.ReadToEnd();
-
-                    dynamic? filterArray = JsonConvert.DeserializeObject(filterJSON);
-
-                    foreach (var item in filterArray)
+                    using (StreamReader jsonStream = new("filters.json"))
                     {
-                        ListViewItem filterItem = new((string)item.name);
-                        filterItem.SubItems.Add((string)item.description);
-                        filterItem.Checked = item.filtered;
+                        filterJSON = jsonStream.ReadToEnd();
 
-                        FilterList.Items.Add(filterItem);
+                        dynamic? filterArray = JsonConvert.DeserializeObject(filterJSON);
+
+                        foreach (var item in filterArray)
+                        {
+                            ListViewItem filterItem = new((string)item.name);
+                            filterItem.SubItems.Add((string)item.description);
+                            filterItem.Checked = item.filtered;
+
+                            FilterList.Items.Add(filterItem);
+                        }
                     }
                 }
             }
@@ -140,23 +145,27 @@ namespace SharpLauncher
             Config.Write();
 
             if (filterJSON.Length > 0)
-                using (FileStream filters = new("filters.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                lock (filterLock)
                 {
-                    // TODO: wtf is this?
-                    lock (filters)
+                    using (FileStream filters = new("filters.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
+                    {
+
                         filters.SetLength(0);
 
-                    dynamic? filterArray = JsonConvert.DeserializeObject(filterJSON);
+                        dynamic? filterArray = JsonConvert.DeserializeObject(filterJSON);
 
-                    int i = 0;
-                    foreach (var item in filterArray)
-                    {
-                        filterArray[i].filtered = FilterList.Items[i].Checked;
-                        i++;
+                        int i = 0;
+                        foreach (var item in filterArray)
+                        {
+                            filterArray[i].filtered = FilterList.Items[i].Checked;
+                            i++;
+                        }
+
+                        filters.Write(Encoding.ASCII.GetBytes(filterArray.ToString()));
                     }
-
-                    filters.Write(Encoding.ASCII.GetBytes(filterArray.ToString()));
                 }
+            }
 
             Config.NeedsRefresh = true;
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -142,6 +142,7 @@ namespace SharpLauncher
             if (filterJSON.Length > 0)
                 using (FileStream filters = new("filters.json", FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite))
                 {
+                    // TODO: wtf is this?
                     lock (filters)
                         filters.SetLength(0);
 

--- a/SharpLauncher.csproj
+++ b/SharpLauncher.csproj
@@ -11,8 +11,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="ObjectListView.Official" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Templates.cs
+++ b/Templates.cs
@@ -1,0 +1,66 @@
+﻿namespace SharpLauncher
+{
+    // A class for holding metadata about a game.
+    public class MetaDataObj
+    {
+        // This maps "internal" database column-names to "external" column-names.
+        // TODO: use this for translations.
+        public static readonly Dictionary<string, string> metadataFields = new()
+        {
+            { "title", "Title" },
+            { "alternateTitles", "Alternate Titles" },
+            { "series", "Series" },
+            { "developer", "Developer" },
+            { "publisher", "Publisher" },
+            { "source", "Source" },
+            { "releaseDate", "Release Date" },
+            { "platform", "Platform" },
+            { "version", "Version" },
+            { "library", "Library" },
+            { "tagsStr", "Tags" },
+            { "language", "Language" },
+            { "playMode", "Play Mode" },
+            { "status", "Status" },
+            { "activeDataOnDisk", "Format" },
+            { "notes", "Notes" },
+            { "originalDescription", "Original Description" }
+        };
+        public string Title { get; set; } = "";
+        public string AlternateTitles { get; set; } = "";
+        public string Series { get; set; } = "";
+        public string Developer { get; set; } = "";
+        public string Publisher { get; set; } = "";
+        public string Source { get; set; } = "";
+        public string ReleaseDate { get; set; } = "";
+        public string Platform { get; set; } = "";
+        public string Version { get; set; } = "";
+        public string Library { get; set; } = "";
+        public string Tags { get; set; } = "";
+        public string Language { get; set; } = "";
+        public string PlayMode { get; set; } = "";
+        public string Status { get; set; } = "";
+        public string Format { get; set; } = "";
+        public string Notes { get; set; } = "";
+        public string OriginalDescription { get; set; } = "";
+
+    }
+
+    // Template for list items
+    public class QueryItem
+    {
+        public string Title { get; set; } = "";
+        public string Developer { get; set; } = "";
+        public string Publisher { get; set; } = "";
+        public string ID { get; set; } = "";
+        public string tagsStr { get; set; } = "";
+    }
+
+    // Template for Add-Apps
+    public class AddApp
+    {
+        public string ID { get; set; } = "";
+        public string ParentGameId { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string ApplicationPath { get; set; } = "";
+    }
+}

--- a/Templates.cs
+++ b/Templates.cs
@@ -53,6 +53,21 @@
         public string Publisher { get; set; } = "";
         public string ID { get; set; } = "";
         public string tagsStr { get; set; } = "";
+        public string GetPropertyFromName(string field)
+        {
+            switch (field.ToLower())
+            {
+                case "title":
+                    return Title;
+                case "developer":
+                    return Developer;
+                case "publisher":
+                    return Publisher;
+                case "id":
+                    return ID;
+            }
+            return "";
+        }
     }
 
     // Template for Add-Apps


### PR DESCRIPTION
Instead of reading the whole DB at once, this reads it in chunks. Once the first 500 (technically, `BlockSize`, but it's 500 by default) results are ready, they're displayed instantly. The rest of the results will be displayed when all the blocks complete.

The result of this is: the first "page" of results is almost always instant. The rest of the results may take a moment, but I don't think that can be sped up without inducing unbearable flickering.

This includes the changes from #1. If you plan to merge this, merge that first.